### PR TITLE
Fixed: Syntax Bug in ___PACKAGENAME___.m File

### DIFF
--- a/___PACKAGENAME___.m
+++ b/___PACKAGENAME___.m
@@ -29,7 +29,7 @@ static ___PACKAGENAME___ *sharedPlugin;
     }
 }
 
-- (id)initWithBundle:(NSBundle *)plugin {
+- (id)initWithBundle:(NSBundle *)plugin
 {
     if (self = [super init]) {
         // reference to plugin's bundle, for resource acccess


### PR DESCRIPTION
Fixed: Syntax Bug in **_PACKAGENAME**_.m File.

There are two left brace after function:-- (id)initWithBundle:(NSBundle *)plugin.
