### PR TITLE
use an optional NSString (CFBundleName may not be available)

### DIFF
--- a/Project Templates/Application Plug-in/Xcode Plugin.xctemplate/___PACKAGENAME___.swift
+++ b/Project Templates/Application Plug-in/Xcode Plugin.xctemplate/___PACKAGENAME___.swift
@@ -13,7 +13,7 @@ class ___PACKAGENAME___: NSObject {
     var bundle: NSBundle
 
     class func pluginDidLoad(bundle: NSBundle) {
-        let appName = NSBundle.mainBundle().infoDictionary!["CFBundleName"] as NSString
+        let appName = NSBundle.mainBundle().infoDictionary?["CFBundleName"] as? NSString
         if appName == "Xcode" {
             sharedPlugin = ___PACKAGENAME___(bundle: bundle)
         }


### PR DESCRIPTION
For example, run 

```
/Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild
```

There's an empty info dictionary and plugins are loaded with an error
