### PR TITLE
Improve plugin loading

### DIFF
--- a/Project Templates/Application Plug-in/Xcode Plugin.xctemplate/TemplateInfo.plist
+++ b/Project Templates/Application Plug-in/Xcode Plugin.xctemplate/TemplateInfo.plist
@@ -53,6 +53,7 @@
 		<string>../___PACKAGENAME___.xcodeproj/xcshareddata/xcschemes/___PACKAGENAME___.xcscheme</string>
 		<string>Info.plist:xcplugin</string>
 		<string>Info.plist:principalClass</string>
+		<string>Info.plist:allowedLoaders</string>
 		<string>Info.plist:NSHumanReadableCopyright</string>
 	</array>
 	<key>Definitions</key>
@@ -159,6 +160,50 @@
 								<key>Path</key>
 								<string>___PACKAGENAME___.m</string>
 							</dict>
+						</dict>
+					</dict>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>Identifier</key>
+			<string>loadInXcodebuild</string>
+			<key>NotPersisted</key>
+			<true/>
+			<key>Name</key>
+			<string>Load in xcodebuild</string>
+			<key>Description</key>
+			<string>Whether the plugin should be loaded in the xcodebuild command line tool</string>
+			<key>Type</key>
+			<string>checkbox</string>
+			<key>Default</key>
+			<string>false</string>
+			<key>Units</key>
+			<dict>
+				<key>true</key>
+				<array>
+					<dict>
+						<key>Definitions</key>
+						<dict>
+							<key>Info.plist:allowedLoaders</key>
+							<string><![CDATA[<key>me.delisa.XcodePluginBase.AllowedLoaders</key>
+<array>
+	<string>com.apple.dt.Xcode</string>
+	<string>com.apple.dt.xcodebuild</string>
+</array>]]></string>
+						</dict>
+					</dict>
+				</array>
+				<key>false</key>
+				<array>
+					<dict>
+						<key>Definitions</key>
+						<dict>
+							<key>Info.plist:allowedLoaders</key>
+							<string><![CDATA[<key>me.delisa.XcodePluginBase.AllowedLoaders</key>
+<array>
+	<string>com.apple.dt.Xcode</string>
+</array>]]></string>
 						</dict>
 					</dict>
 				</array>

--- a/Project Templates/Application Plug-in/Xcode Plugin.xctemplate/___PACKAGENAME___.m
+++ b/Project Templates/Application Plug-in/Xcode Plugin.xctemplate/___PACKAGENAME___.m
@@ -39,7 +39,7 @@ static ___PACKAGENAME___ *sharedPlugin;
                                                          name:NSApplicationDidFinishLaunchingNotification
                                                        object:nil];
         } else {
-            [self initialize];
+            [self initializeAndLog];
         }
     }
     return self;
@@ -48,12 +48,20 @@ static ___PACKAGENAME___ *sharedPlugin;
 - (void)applicationDidFinishLaunching:(NSNotification *)notification
 {
     [[NSNotificationCenter defaultCenter] removeObserver:self name:NSApplicationDidFinishLaunchingNotification object:nil];
-    [self initialize];
+    [self initializeAndLog];
+}
+
+- (void)initializeAndLog
+{
+    NSString *name = [self.bundle objectForInfoDictionaryKey:@"CFBundleName"];
+    NSString *version = [self.bundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+    NSString *status = [self initialize] ? @"loaded successfully" : @"failed to load";
+    NSLog(@"🔌 Plugin %@ %@ %@", name, version, status);
 }
 
 #pragma mark - Implementation
 
-- (void)initialize
+- (BOOL)initialize
 {
     // Create menu items, initialize UI, etc.
     // Sample Menu Item:
@@ -64,6 +72,9 @@ static ___PACKAGENAME___ *sharedPlugin;
         //[actionMenuItem setKeyEquivalentModifierMask:NSAlphaShiftKeyMask | NSControlKeyMask];
         [actionMenuItem setTarget:self];
         [[menuItem submenu] addItem:actionMenuItem];
+        return YES;
+    } else {
+        return NO;
     }
 }
 

--- a/Project Templates/Application Plug-in/Xcode Plugin.xctemplate/___PACKAGENAME___.m
+++ b/Project Templates/Application Plug-in/Xcode Plugin.xctemplate/___PACKAGENAME___.m
@@ -10,11 +10,6 @@
 
 static ___PACKAGENAME___ *sharedPlugin;
 
-@interface ___PACKAGENAME___()
-
-@property (nonatomic, strong, readwrite) NSBundle *bundle;
-@end
-
 @implementation ___PACKAGENAME___
 
 + (void)pluginDidLoad:(NSBundle *)plugin
@@ -33,11 +28,11 @@ static ___PACKAGENAME___ *sharedPlugin;
     return sharedPlugin;
 }
 
-- (id)initWithBundle:(NSBundle *)plugin
+- (id)initWithBundle:(NSBundle *)bundle
 {
     if (self = [super init]) {
         // reference to plugin's bundle, for resource access
-        self.bundle = plugin;
+        _bundle = bundle;
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(didApplicationFinishLaunchingNotification:)
                                                      name:NSApplicationDidFinishLaunchingNotification

--- a/Project Templates/Application Plug-in/Xcode Plugin.xctemplate/___PACKAGENAME___.m
+++ b/Project Templates/Application Plug-in/Xcode Plugin.xctemplate/___PACKAGENAME___.m
@@ -14,12 +14,9 @@ static ___PACKAGENAME___ *sharedPlugin;
 
 + (void)pluginDidLoad:(NSBundle *)plugin
 {
-    static dispatch_once_t onceToken;
-    NSString *currentApplicationName = [[NSBundle mainBundle] infoDictionary][@"CFBundleName"];
-    if ([currentApplicationName isEqual:@"Xcode"]) {
-        dispatch_once(&onceToken, ^{
-            sharedPlugin = [[self alloc] initWithBundle:plugin];
-        });
+    NSArray *allowedLoaders = [plugin objectForInfoDictionaryKey:@"me.delisa.XcodePluginBase.AllowedLoaders"];
+    if ([allowedLoaders containsObject:[[NSBundle mainBundle] bundleIdentifier]]) {
+        sharedPlugin = [[self alloc] initWithBundle:plugin];
     }
 }
 

--- a/Project Templates/Application Plug-in/Xcode Plugin.xctemplate/___PACKAGENAME___.m
+++ b/Project Templates/Application Plug-in/Xcode Plugin.xctemplate/___PACKAGENAME___.m
@@ -12,6 +12,8 @@ static ___PACKAGENAME___ *sharedPlugin;
 
 @implementation ___PACKAGENAME___
 
+#pragma mark - Initialization
+
 + (void)pluginDidLoad:(NSBundle *)plugin
 {
     NSArray *allowedLoaders = [plugin objectForInfoDictionaryKey:@"me.delisa.XcodePluginBase.AllowedLoaders"];
@@ -30,19 +32,29 @@ static ___PACKAGENAME___ *sharedPlugin;
     if (self = [super init]) {
         // reference to plugin's bundle, for resource access
         _bundle = bundle;
-        [[NSNotificationCenter defaultCenter] addObserver:self
-                                                 selector:@selector(didApplicationFinishLaunchingNotification:)
-                                                     name:NSApplicationDidFinishLaunchingNotification
-                                                   object:nil];
+        // NSApp may be nil if the plugin is loaded from the xcodebuild command line tool
+        if (NSApp && !NSApp.mainMenu) {
+            [[NSNotificationCenter defaultCenter] addObserver:self
+                                                     selector:@selector(applicationDidFinishLaunching:)
+                                                         name:NSApplicationDidFinishLaunchingNotification
+                                                       object:nil];
+        } else {
+            [self initialize];
+        }
     }
     return self;
 }
 
-- (void)didApplicationFinishLaunchingNotification:(NSNotification*)noti
+- (void)applicationDidFinishLaunching:(NSNotification *)notification
 {
-    //removeObserver
     [[NSNotificationCenter defaultCenter] removeObserver:self name:NSApplicationDidFinishLaunchingNotification object:nil];
-    
+    [self initialize];
+}
+
+#pragma mark - Implementation
+
+- (void)initialize
+{
     // Create menu items, initialize UI, etc.
     // Sample Menu Item:
     NSMenuItem *menuItem = [[NSApp mainMenu] itemWithTitle:@"Edit"];
@@ -61,11 +73,6 @@ static ___PACKAGENAME___ *sharedPlugin;
     NSAlert *alert = [[NSAlert alloc] init];
     [alert setMessageText:@"Hello, World"];
     [alert runModal];
-}
-
-- (void)dealloc
-{
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 @end

--- a/Project Templates/Application Plug-in/Xcode Plugin.xctemplate/___PACKAGENAME___.swift
+++ b/Project Templates/Application Plug-in/Xcode Plugin.xctemplate/___PACKAGENAME___.swift
@@ -15,8 +15,8 @@ class ___PACKAGENAME___: NSObject {
     lazy var center = NSNotificationCenter.defaultCenter()
 
     class func pluginDidLoad(bundle: NSBundle) {
-        let appName = NSBundle.mainBundle().infoDictionary?["CFBundleName"] as? NSString
-        if appName == "Xcode" {
+        let allowedLoaders = bundle.objectForInfoDictionaryKey("me.delisa.XcodePluginBase.AllowedLoaders") as! Array<String>
+        if allowedLoaders.contains(NSBundle.mainBundle().bundleIdentifier ?? "") {
             sharedPlugin = ___PACKAGENAME___(bundle: bundle)
         }
     }

--- a/Project Templates/Application Plug-in/Xcode Plugin.xctemplate/___PACKAGENAME___.swift
+++ b/Project Templates/Application Plug-in/Xcode Plugin.xctemplate/___PACKAGENAME___.swift
@@ -14,6 +14,8 @@ class ___PACKAGENAME___: NSObject {
     var bundle: NSBundle
     lazy var center = NSNotificationCenter.defaultCenter()
 
+    // MARK: - Initialization
+
     class func pluginDidLoad(bundle: NSBundle) {
         let allowedLoaders = bundle.objectForInfoDictionaryKey("me.delisa.XcodePluginBase.AllowedLoaders") as! Array<String>
         if allowedLoaders.contains(NSBundle.mainBundle().bundleIdentifier ?? "") {
@@ -25,20 +27,22 @@ class ___PACKAGENAME___: NSObject {
         self.bundle = bundle
 
         super.init()
-        center.addObserver(self, selector: #selector(self.createMenuItems), name: NSApplicationDidFinishLaunchingNotification, object: nil)
+        // NSApp may be nil if the plugin is loaded from the xcodebuild command line tool
+        if (NSApp != nil && NSApp.mainMenu == nil) {
+            center.addObserver(self, selector: #selector(self.applicationDidFinishLaunching), name: NSApplicationDidFinishLaunchingNotification, object: nil)
+        } else {
+            initialize()
+        }
     }
 
-    deinit {
-        removeObserver()
+    func applicationDidFinishLaunching() {
+        center.removeObserver(self, name: NSApplicationDidFinishLaunchingNotification, object: nil)
+        initialize()
     }
 
-    func removeObserver() {
-        center.removeObserver(self)
-    }
+    // MARK: - Implementation
 
-    func createMenuItems() {
-        removeObserver()
-
+    func initialize() {
         guard let mainMenu = NSApp.mainMenu else { return }
         guard let item = mainMenu.itemWithTitle("Edit") else { return }
         guard let submenu = item.submenu else { return }

--- a/Project Templates/Application Plug-in/Xcode Plugin.xctemplate/___PACKAGENAME___.swift
+++ b/Project Templates/Application Plug-in/Xcode Plugin.xctemplate/___PACKAGENAME___.swift
@@ -31,27 +31,36 @@ class ___PACKAGENAME___: NSObject {
         if (NSApp != nil && NSApp.mainMenu == nil) {
             center.addObserver(self, selector: #selector(self.applicationDidFinishLaunching), name: NSApplicationDidFinishLaunchingNotification, object: nil)
         } else {
-            initialize()
+            initializeAndLog()
         }
+    }
+
+    private func initializeAndLog() {
+        let name = bundle.objectForInfoDictionaryKey("CFBundleName")
+        let version = bundle.objectForInfoDictionaryKey("CFBundleShortVersionString")
+        let status = initialize() ? "loaded successfully" : "failed to load"
+        NSLog("🔌 Plugin \(name) \(version) \(status)")
     }
 
     func applicationDidFinishLaunching() {
         center.removeObserver(self, name: NSApplicationDidFinishLaunchingNotification, object: nil)
-        initialize()
+        initializeAndLog()
     }
 
     // MARK: - Implementation
 
-    func initialize() {
-        guard let mainMenu = NSApp.mainMenu else { return }
-        guard let item = mainMenu.itemWithTitle("Edit") else { return }
-        guard let submenu = item.submenu else { return }
+    func initialize() -> Bool {
+        guard let mainMenu = NSApp.mainMenu else { return false }
+        guard let item = mainMenu.itemWithTitle("Edit") else { return false }
+        guard let submenu = item.submenu else { return false }
 
         let actionMenuItem = NSMenuItem(title:"Do Action", action:#selector(self.doMenuAction), keyEquivalent:"")
         actionMenuItem.target = self
 
         submenu.addItem(NSMenuItem.separatorItem())
         submenu.addItem(actionMenuItem)
+
+        return true
     }
 
     func doMenuAction() {


### PR DESCRIPTION
* Make it possible to load a plugin in `xcodebuild` in addition to Xcode with a checkbox in the wizard
* Support for Alcatraz loading (no need to restart Xcode after installing a plugin)
* Log a message when the plugin is loaded