### PR TITLE
Improvements to the xcscheme file

### DIFF
--- a/Project Templates/Application Plug-in/Xcode Plugin.xctemplate/TemplateInfo.plist
+++ b/Project Templates/Application Plug-in/Xcode Plugin.xctemplate/TemplateInfo.plist
@@ -66,6 +66,8 @@
 				</array>
 			<key>Path</key>
 			<string>___PACKAGENAME___.xcscheme</string>
+			<key>TargetIndices</key>
+			<array/>
 		</dict>
 		<key>Info.plist:xcplugin</key>
 		<string>&lt;key&gt;XCPluginHasUI&lt;/key&gt;

--- a/Project Templates/Application Plug-in/Xcode Plugin.xctemplate/___PACKAGENAME___.xcscheme
+++ b/Project Templates/Application Plug-in/Xcode Plugin.xctemplate/___PACKAGENAME___.xcscheme
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0500"
-   version = "2.0">
+   LastUpgradeVersion = "0730"
+   version = "1.3">
    <BuildAction
-      parallelizeBuildables = "NO"
-      buildImplicitDependencies = "NO">
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -23,25 +23,28 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
-      debugDocumentVersioning = "NO"
-      debugXPCServices = "NO"
-      allowLocationSimulation = "NO"
-      viewDebuggingEnabled = "No">
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
       <PathRunnable
+         runnableDebuggingMode = "0"
+         BundleIdentifier = "com.apple.dt.Xcode"
          FilePath = "/Applications/Xcode.app">
       </PathRunnable>
       <MacroExpansion>
@@ -63,11 +66,20 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "890A4B3E171F031300AFE577"
+            BuildableName = "___PACKAGENAME___.xcplugin"
+            BlueprintName = "___PACKAGENAME___"
+            ReferencedContainer = "container:___PACKAGENAME___.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Project Templates/Application Plug-in/Xcode Plugin.xctemplate/___PACKAGENAME___.xcscheme
+++ b/Project Templates/Application Plug-in/Xcode Plugin.xctemplate/___PACKAGENAME___.xcscheme
@@ -20,20 +20,6 @@
                ReferencedContainer = "container:___PACKAGENAME___.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "NO"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "8966AFCA173EB7BF004150C0"
-               BuildableName = "___PACKAGENAME___Tests.xctest"
-               BlueprintName = "___PACKAGENAME___Tests"
-               ReferencedContainer = "container:___PACKAGENAME___.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/Project Templates/Application Plug-in/Xcode Plugin.xctemplate/___PACKAGENAME___.xcscheme
+++ b/Project Templates/Application Plug-in/Xcode Plugin.xctemplate/___PACKAGENAME___.xcscheme
@@ -67,6 +67,12 @@
             ReferencedContainer = "container:___PACKAGENAME___.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-PluginLoadingLogLevel 3"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/Project Templates/Application Plug-in/Xcode Plugin.xctemplate/___PACKAGENAME___.xcscheme
+++ b/Project Templates/Application Plug-in/Xcode Plugin.xctemplate/___PACKAGENAME___.xcscheme
@@ -38,7 +38,7 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      ignoresPersistentStateOnLaunch = "NO"
+      ignoresPersistentStateOnLaunch = "YES"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">


### PR DESCRIPTION
- Do not add the .xcscheme file in the _Copy Bundle Resources_ phase
- Add Xcode plugin loading debug logs in xcscheme
- Launch Xcode without state restoration (This makes it much easier to distinguish between the _debugging_ Xcode and the _debugged_ Xcode.)
- Cleanup
